### PR TITLE
Fix critical clippy warnings

### DIFF
--- a/src/accumulator/metal_impl.rs
+++ b/src/accumulator/metal_impl.rs
@@ -156,7 +156,7 @@ impl MetalAccumulator {
                 );
 
                 let threads_per_group = MTLSize::new(256, 1, 1);
-                let thread_groups = MTLSize::new((n_padded as u64 + 255) / 256, 1, 1);
+                let thread_groups = MTLSize::new((n_padded as u64).div_ceil(256), 1, 1);
 
                 encoder.dispatch_thread_groups(thread_groups, threads_per_group);
                 encoder.end_encoding();

--- a/src/accumulator/neon.rs
+++ b/src/accumulator/neon.rs
@@ -345,7 +345,7 @@ unsafe fn neon_hybrid_sort(col_indices: &[usize], values: &[f32]) -> (Vec<usize>
 
     // Process in chunks of 16 using NEON
     let chunk_size = 16;
-    let num_chunks = (len + chunk_size - 1) / chunk_size;
+    let num_chunks = len.div_ceil(chunk_size);
 
     let mut all_indices = Vec::with_capacity(len);
     let mut all_values = Vec::with_capacity(len);

--- a/src/accumulator/simd.rs
+++ b/src/accumulator/simd.rs
@@ -52,14 +52,14 @@ where
         let mut current_idx = pairs[0].0;
         let mut current_val = pairs[0].1;
 
-        for i in 1..pairs.len() {
-            if pairs[i].0 == current_idx {
-                current_val += pairs[i].1;
+        for pair in pairs.iter().skip(1) {
+            if pair.0 == current_idx {
+                current_val += pair.1;
             } else {
                 result_indices.push(current_idx);
                 result_values.push(current_val);
-                current_idx = pairs[i].0;
-                current_val = pairs[i].1;
+                current_idx = pair.0;
+                current_val = pair.1;
             }
         }
 

--- a/src/matrix/categorization.rs
+++ b/src/matrix/categorization.rs
@@ -69,7 +69,7 @@ where
     // Fixed memory overhead for fine-level structures (using 2 as default chunk_log)
     let chunk_log = 2; // Default from paper, will be tuned later
     let chunk_size = 1 << chunk_log;
-    let n_chunks = (b.n_cols + chunk_size - 1) / chunk_size;
+    let n_chunks = b.n_cols.div_ceil(chunk_size);
 
     // Iterate through each row of A and categorize it
     for i in 0..a.n_rows {
@@ -143,8 +143,10 @@ where
 {
     let categories = categorize_rows(a, b, config);
 
-    let mut summary = CategorizationSummary::default();
-    summary.total_rows = categories.len();
+    let mut summary = CategorizationSummary {
+        total_rows: categories.len(),
+        ..Default::default()
+    };
 
     for category in categories {
         match category {

--- a/src/reordering/mod.rs
+++ b/src/reordering/mod.rs
@@ -65,7 +65,7 @@ impl ChunkMetadata {
         };
 
         // Calculate number of chunks needed
-        let n_chunks = (total_elements + chunk_length - 1) / chunk_length;
+        let n_chunks = total_elements.div_ceil(chunk_length);
 
         // Calculate shift bits for power-of-2 chunk size
         // This is a fast way to compute the chunk index: col >> shift_bits


### PR DESCRIPTION
- Add type alias for complex CSR components type in metal.rs
- Refactor spgemm_metal to accept SparseMatrixCSR structs instead of individual arrays
- Add type alias for BatchResults in parallel.rs
- Fix needless_range_loop issues by using iterators
- Fix field_reassign_with_default in categorization
- Fix extend_with_drain by using append
- Fix manual_div_ceil warnings by using div_ceil method

Reduces clippy errors from 22 to 12. Remaining issues are mostly too_many_arguments warnings that require larger refactoring.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues using #issue_number format -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI changes

## Testing
<!-- Describe how you tested these changes -->

## Performance Impact
<!-- If applicable, describe any performance impacts -->

## Checklist
- [ ] My code follows the project's code style
- [ ] I have added/updated relevant tests
- [ ] All tests pass locally
- [ ] I have updated the documentation as needed
- [ ] My changes do not introduce new warnings

## Additional Notes
<!-- Any additional information that reviewers should know -->